### PR TITLE
feat: Add new model deployment: spaceflights_panda/2

### DIFF
--- a/NaN-spec.yaml
+++ b/NaN-spec.yaml
@@ -1,0 +1,17 @@
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: 
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: mlflow-custom
+      protocolVersion: v2
+      modelVersion: spaceflights_panda/2
+      resources: limits:
+  cpu: 500m
+  memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 1Gi


### PR DESCRIPTION
This PR is to deploy model: spaceflights_panda/2 to run on schedule: 0 8 * * *